### PR TITLE
Added gRPC Web Support

### DIFF
--- a/runtime/Cargo.lock
+++ b/runtime/Cargo.lock
@@ -1569,6 +1569,9 @@ dependencies = [
  "toml",
  "tonic",
  "tonic-build",
+ "tonic-web",
+ "tower",
+ "tower-http",
 ]
 
 [[package]]
@@ -2052,6 +2055,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "tonic-web"
+version = "0.12.3"
+source = "git+https://github.com/hatomist/tonic-milkv.git#8aa1c2914c49ad15c5b91b1a66f965defdcea2af"
+dependencies = [
+ "base64",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pin-project",
+ "tokio-stream",
+ "tonic",
+ "tower-http",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
 name = "tower"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2068,6 +2090,20 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8437150ab6bbc8c5f0f519e3d5ed4aa883a83dd4cdd3d1b21f9482936046cb97"
+dependencies = [
+ "bitflags 2.6.0",
+ "bytes",
+ "http",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -26,8 +26,11 @@ clap = { version = "4.5.19", features = ["derive"] }
 serde_json = "1.0.128"
 chrono = "0.4.38"
 tonic = { git = "https://github.com/hatomist/tonic-milkv.git" }
+tonic-web = { git = "https://github.com/hatomist/tonic-milkv.git" }
 prost = "0.13"
 tokio = { version = "1.40.0", features = ["full", "macros", "rt-multi-thread"] }
+tower= "0.5"
+tower-http = "0.6"
 
 # Conditional dependencies
 i2cdev = { version = "0.6.1", optional = true }

--- a/runtime/build.rs
+++ b/runtime/build.rs
@@ -5,7 +5,6 @@ fn main() {
         println!("cargo:rustc-link-lib=dylib=cviwrapper");
     }
 
-    use tonic_build;
     tonic_build::compile_protos("proto/hal_pb.proto").unwrap();
 
     println!("cargo:rerun-if-changed=build.rs");


### PR DESCRIPTION
This commit adds gRPC web support to ensure that we can interface with the robot via JavaScript / directly from the web browser. Normally you would need a proxy to convert http -> http/2 grpc requests.