### PR TITLE
milkv kinfer for zbot2

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,7 @@
 [submodule "buildroot"]
 	path = buildroot
 	url = https://github.com/zeroth-robotics/buildroot
+[submodule "kinfer"]
+	path = kinfer
+	url = https://github.com/kscalelabs/kinfer.git
+	branch = milkv-infer

--- a/runtime/kos_platform/Cargo.toml
+++ b/runtime/kos_platform/Cargo.toml
@@ -9,6 +9,7 @@ description = "KOS platform for Zeroth-01"
 
 [dependencies]
 kos_core = { version = "0.1.2", path = "../../kos_core" }
+kinfer = { path = "../../kinfer/kinfer/rust" } 
 async-trait = "0.1"
 eyre = "0.6"
 serde = { version = "1.0", features = ["derive"] }

--- a/runtime/kos_platform/src/actuator.rs
+++ b/runtime/kos_platform/src/actuator.rs
@@ -10,24 +10,64 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use tokio::sync::RwLock;
 use tonic::{Request, Response, Status};
+use lazy_static::lazy_static;
 
 pub struct ZBotActuator {
     supervisor: Arc<RwLock<FeetechSupervisor>>,
+}
+pub const ZBOT_ALL_ACTUATOR_IDS: [u32; 16] = [1, 2, 3, 4, 5,
+                                   6, 7, 8, 9, 10,
+                                   11, 12, 13,
+                                   14, 15, 16];
+
+                                   
+lazy_static! {
+    pub static ref JOINT_NAME_TO_ID: HashMap<String, u32> = {
+        let mut map = HashMap::new();
+        // Right leg
+        map.insert("right_ankle_pitch".to_string(), 1);
+        map.insert("right_knee_pitch".to_string(), 2);
+        map.insert("right_hip_roll".to_string(), 3);
+        map.insert("right_hip_yaw".to_string(), 4);
+        map.insert("right_hip_pitch".to_string(), 5);
+        
+        // Left leg
+        map.insert("left_ankle_pitch".to_string(), 6);
+        map.insert("left_knee_pitch".to_string(), 7);
+        map.insert("left_hip_roll".to_string(), 8);
+        map.insert("left_hip_yaw".to_string(), 9);
+        map.insert("left_hip_pitch".to_string(), 10);
+        
+        // Right arm
+        map.insert("right_elbow_yaw".to_string(), 11);
+        map.insert("right_shoulder_yaw".to_string(), 12);
+        map.insert("right_shoulder_pitch".to_string(), 13);
+        
+        // Left arm
+        map.insert("left_shoulder_pitch".to_string(), 14);
+        map.insert("left_shoulder_yaw".to_string(), 15);
+        map.insert("left_elbow_yaw".to_string(), 16);
+        
+        map
+    };
+
+    pub static ref ID_TO_JOINT_NAME: HashMap<u32, String> = {
+        let mut map = HashMap::new();
+        for (name, &id) in JOINT_NAME_TO_ID.iter() {
+            map.insert(id, name.clone());
+        }
+        map
+    };
 }
 
 impl ZBotActuator {
     pub async fn new() -> Result<Self> {
         let mut supervisor = FeetechSupervisor::new()?;
 
-        // Add the servo with ID 1
-
-        let actuator_list = [1, 2, 3, 4, 5,
-                            6, 7, 8, 9, 10,
-                            11, 12, 13,
-                            14, 15, 16];
-        for id in actuator_list {
+        // Add the servos
+        for id in ZBOT_ALL_ACTUATOR_IDS {
             supervisor
-                .add_servo(id, FeetechActuatorType::Sts3215)
+                .add_servo(id as u8, FeetechActuatorType::Sts3215)
                 .await?;
         }
 

--- a/runtime/kos_platform/src/inference.rs
+++ b/runtime/kos_platform/src/inference.rs
@@ -1,0 +1,266 @@
+use async_trait::async_trait;
+use eyre::Result;
+use kos_core::{
+    google_proto::longrunning::Operation,
+    hal::{Inference, InferenceState},
+    kos_proto::{
+        common::{ActionResponse, Error, ErrorCode},
+        inference::*,
+    },
+};
+use kinfer::{ModelRunner, MilkVModelRunner, kinfer_proto::ProtoIO};
+use std::{sync::Arc, path::Path};
+use tokio::sync::RwLock;
+use tracing::{debug, error, info};
+
+use crate::{actuator::{ZBotActuator, ZBOT_ALL_ACTUATOR_IDS}, imu::ZBotIMU};
+
+const MILKV_STANDING_MODEL_PATH: &str = "/root/models/ppo_standing.cvimodel";
+
+pub struct ZBotInference {
+    model: Arc<RwLock<Option<MilkVModelRunner>>>,
+    imu: Arc<ZBotIMU>,
+    actuator: Arc<ZBotActuator>,
+    state: Arc<RwLock<InferenceState>>,
+}
+
+impl ZBotInference {
+    pub fn new(imu: Arc<ZBotIMU>, actuator: Arc<ZBotActuator>) -> Self {
+        let model = match MilkVModelRunner::new(MILKV_STANDING_MODEL_PATH) {
+            Ok(model) => Some(model),
+            Err(e) => {
+                error!("Failed to load default model: {}", e);
+                None
+            }
+        };
+        Self {
+            model: Arc::new(RwLock::new(model)),
+            imu,
+            actuator,
+            state: Arc::new(RwLock::new(InferenceState::Stopped)),
+        }
+    }
+
+    async fn get_sensor_data(&self) -> Result<(IMUData, Vec<ActuatorStateResponse>)> {
+        let imu_data = self.imu.get_values().await?;
+        let actuator_data = self.actuator.get_actuators_state(ZBOT_ALL_ACTUATOR_IDS).await?;
+        Ok((imu_data, actuator_data))
+    }
+
+    async fn pack_inputs_to_proto(
+        &self,
+        imu_data: IMUData,
+        actuator_data: Vec<ActuatorStateResponse>,
+    ) -> Result<ProtoIO> {
+        let model = self.model.read().await;
+        let model = model.as_ref().ok_or_else(|| eyre!("No model loaded"))?;
+        
+        let input_schema = model.input_schema()?;
+        let mut proto_values = Vec::new();
+
+        for value_schema in input_schema.values {
+            match value_schema.value_type {
+                Some(ValueType::JointPositions(ref joint_positions_schema)) => {
+                    // Create position map for quick lookup from id
+                    let position_map: HashMap<u32, f64> = actuator_data.iter()
+                        .filter_map(|state| state.position.map(|pos| (state.actuator_id, pos)))
+                        .collect();
+
+                    // Pack joint positions into proto value with the proper order
+                    let joint_positions = JointPositionsValue {
+                        values: joint_positions_schema.joint_names.iter()
+                            .map(|joint_name| {
+                                let value = JOINT_NAME_TO_ID.get(joint_name)
+                                    .and_then(|&id| position_map.get(&id))
+                                    .map(|&pos| pos as f32)
+                                    .unwrap_or(0.0);
+
+                                JointPositionValue {
+                                    joint_name: joint_name.clone(),
+                                    value,
+                                    unit: joint_positions_schema.unit, // Use schema-defined unit
+                                }
+                            })
+                            .collect(),
+                    };
+
+                    let proto_value = ProtoValue {
+                        value: Some(EnumValue::JointPositions(joint_positions))
+                    };
+
+                    proto_values.push((value_schema.value_name, proto_value));
+                }
+                Some(ValueType::Imu(ref imu_schema)) => {
+                    let mut imu_values = Vec::new();
+                    if imu_schema.use_accelerometer {
+                        imu_values.extend_from_slice(&[
+                            imu_data.accel_x as f32,
+                            imu_data.accel_y as f32,
+                            imu_data.accel_z as f32,
+                        ]);
+                    }
+                    if imu_schema.use_gyroscope {
+                        imu_values.extend_from_slice(&[
+                            imu_data.gyro_x as f32,
+                            imu_data.gyro_y as f32,
+                            imu_data.gyro_z as f32,
+                        ]);
+                    }
+                    if imu_schema.use_magnetometer {
+                        imu_values.extend_from_slice(&[
+                            imu_data.mag_x as f32,
+                            imu_data.mag_y as f32,
+                            imu_data.mag_z as f32,
+                        ]);
+                    }
+                    
+                    proto_values.push((value_schema.value_name, imu_values));
+                },
+                Some(ValueType::VectorCommand(ref vector_command_schema)) => {
+                    // Default command vector of specified dimension
+                    // TODO: replace with actual command vector (teleop?)
+                    let command = vec![0.0f32; vector_command_schema.dimensions as usize];
+                    proto_values.push((value_schema.value_name, command));
+                },
+                _ => {
+                    error!("Unsupported input value type in schema");
+                    return Err(eyre!("Unsupported input value type"));
+                }
+            }
+        }
+
+        Ok(ProtoIO {
+            values: proto_values,
+        })
+    }
+
+    async fn unpack_outputs_from_proto(&self, output: ProtoIO) -> Result<Vec<ActuatorCommand>> {
+        let model = self.model.read().await;
+        let model = model.as_ref().ok_or_else(|| eyre::eyre!("No model loaded"))?;
+
+        let output_schema = model.output_schema()?;
+        let mut actuator_commands = Vec::new();
+
+        for (value_schema, proto_value) in output_schema.values.iter().zip(output.values.iter()) {
+            match &value_schema.value_type {
+                Some(ValueType::JointCommands(ref joint_commands_schema)) => {
+                    if let Some(EnumValue::JointCommands(commands)) = &proto_value.value {
+                        // Convert joint commands values to actuator commands
+                        for joint_cmd in &commands.values {
+                            // Look up actuator ID from joint name
+                            if let Some(&actuator_id) = JOINT_NAME_TO_ID.get(&joint_cmd.joint_name) {
+                                actuator_commands.push(ActuatorCommand {
+                                    actuator_id,
+                                    position: Some(joint_cmd.position as f64),
+                                    velocity: None, // TODO: Velocity control not implemented yet
+                                });
+                            }
+                        }
+                    }
+                }
+                _ => {
+                    error!("Unsupported output value type in schema");
+                    return Err(eyre!("Unsupported output value type"));
+                }
+            }
+        }
+
+        Ok(actuator_commands)
+    }
+
+    async fn run_inference_cycle(&self) -> Result<()> {
+        let model = self.model.read().await;
+        let model = model.as_ref().ok_or_else(|| eyre::eyre!("No model loaded"))?;
+
+        let (imu_data, actuator_data) = self.get_sensor_data().await?;
+        
+        let inputs = self.pack_inputs_to_proto(imu_data, actuator_data).await?;
+        let outputs = model.run(inputs)?;
+        let actuator_commands = self.unpack_outputs_from_proto(outputs).await?;
+
+        self.actuator.command_actuators(actuator_commands).await?;
+
+        Ok(())
+    }
+}
+
+#[async_trait]
+impl Inference for ZBotInference {
+    async fn load_model(&self, path: String) -> Result<ActionResponse> {
+        info!("Loading model from: {}", path);
+        
+        let model = match MilkVModelRunner::new(Path::new(&path)) {
+            Ok(model) => model,
+            Err(e) => {
+                error!("Failed to load model: {}", e);
+                return Ok(ActionResponse {
+                    success: false,
+                    error: Some(Error {
+                        code: ErrorCode::InvalidArgument as i32,
+                        message: format!("Failed to load model: {}", e),
+                    }),
+                });
+            }
+        };
+
+        let mut model_guard = self.model.write().await;
+        *model_guard = Some(model);
+
+        Ok(ActionResponse {
+            success: true,
+            error: None,
+        })
+    }
+
+    async fn start(&self) -> Result<ActionResponse> {
+        let mut state = self.state.write().await;
+        
+        if *state == InferenceState::Running {
+            return Ok(ActionResponse {
+                success: false,
+                error: Some(Error {
+                    code: ErrorCode::AlreadyExists as i32,
+                    message: "Inference is already running".to_string(),
+                }),
+            });
+        }
+
+        // Start inference loop in background task
+        let self_clone = Arc::new(self.clone());
+        tokio::spawn(async move {
+            loop {
+                let state = self_clone.state.read().await;
+                if *state != InferenceState::Running {
+                    break;
+                }
+                
+                if let Err(e) = self_clone.run_inference_cycle().await {
+                    error!("Inference cycle failed: {}", e);
+                }
+                
+                tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+            }
+        });
+
+        *state = InferenceState::Running;
+
+        Ok(ActionResponse {
+            success: true,
+            error: None,
+        })
+    }
+
+    async fn stop(&self) -> Result<ActionResponse> {
+        let mut state = self.state.write().await;
+        *state = InferenceState::Stopped;
+
+        Ok(ActionResponse {
+            success: true,
+            error: None,
+        })
+    }
+
+    async fn get_state(&self) -> Result<InferenceState> {
+        Ok(*self.state.read().await)
+    }
+}

--- a/runtime/kos_platform/src/lib.rs
+++ b/runtime/kos_platform/src/lib.rs
@@ -1,11 +1,12 @@
 mod actuator;
 mod firmware;
 mod imu;
+mod inference; 
 
 pub use actuator::*;
 pub use firmware::*;
 pub use imu::*;
-
+pub use inference::*;
 use kos_core::kos_proto::actuator::actuator_service_server::ActuatorServiceServer;
 use kos_core::kos_proto::imu::imu_service_server::ImuServiceServer;
 use kos_core::services::{ActuatorServiceImpl, IMUServiceImpl, OperationsServiceImpl};
@@ -65,6 +66,11 @@ impl Platform for ZBotPlatform {
                     eprintln!("Failed to initialize IMU: {}", e);
                 }
             }
+
+            let inference = ZBotInference::new(imu, actuator);
+            services.push(ServiceEnum::Inference(InferenceServiceServer::new(
+                InferenceServiceImpl::new(Arc::new(inference)),
+            )));
 
             Ok(services)
         })

--- a/runtime/src/controller.rs
+++ b/runtime/src/controller.rs
@@ -9,109 +9,66 @@ use ndarray::Array1;
 pub struct Robot{
 
     servo: Servo,
-    cycle_time: f32,
-    prev_actions: [f32; 10],
-    prev_buffer: [f32; 615],
 }
 
 impl Robot{
     pub fn new() -> Result<Self> {
         let servo = Servo::new()?;
 
-        Ok(Self { servo, cycle_time: 0.5, prev_actions: [0.0; 10], prev_buffer: [0.0; 615] })
+        Ok(Self { servo })
     }
 
-    pub async fn run(&mut self, model: Arc<Model>) -> Result<()> {
+    pub async fn run(&self, model: Arc<Model>) -> Result<()> {
         let mut control_interval = interval(Duration::from_millis(20));
 
         loop {
             control_interval.tick().await;
 
             // get joint states
-            let model_input = self.get_robot_state().await?;
+            let current_joint_states = self.get_joint_states().await?;
             
             // get desired joint positions (inferenced from model)
-            let desired_joint_positions = self.model_inference(&model, &model_input).await?;
+            let desired_joint_positions = self.model_inference(&model, &current_joint_states).await?;
             
             // send joint commands
             self.send_joint_commands(&desired_joint_positions).await?;
         }
     }
 
-    async fn get_robot_state(&self) -> Result<[f32; 656]> {
+    async fn get_joint_states(&self) -> Result<[f32; 16]> {
         let servo_data = self.servo.read_continuous()?;
-        // first 3 elements are x_vel, y_vel, rot, (set to 0)
-        // t is current time
-        // dof_pos is current joint positions
-        // dof_vel is current joint velocities
-        // prev_actions is previous actions
-        // imu_ang_vel is angular velocity of the IMU
-        // imu_euler_xyz is euler angles of the IMU
-        let mut combined_robot_state = [0.0; 656]; // 41 + 615
-
-        let time = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs_f32();
-        
-        let sin_time = (2.0 * std::f32::consts::PI * time / self.cycle_time).sin();
-        let cos_time = (2.0 * std::f32::consts::PI * time / self.cycle_time).cos();
-
-        combined_robot_state[3] = sin_time;
-        combined_robot_state[4] = cos_time;
-
-        let joint_positions: [f32; 10] = servo_data.servo.iter()
-            .take(10)
-            .map(|s| s.current_location as f32)
+        let joint_states: [f32; 16] = servo_data.servo.iter()
+            .take(16)
+            .map(|s| s.target_location as f32)
             .collect::<Vec<f32>>()
             .try_into()
-            .unwrap_or([0.0; 10]);
-
-        let joint_velocities: [f32; 10] = servo_data.servo.iter()
-            .take(10)
-            .map(|s| s.current_speed as f32)
-            .collect::<Vec<f32>>()
-            .try_into()
-            .unwrap_or([0.0; 10]);
-
-        combined_robot_state[5..15].copy_from_slice(&joint_positions);
-        combined_robot_state[15..25].copy_from_slice(&joint_velocities);
-        combined_robot_state[25..35].copy_from_slice(&self.prev_actions);
-
-        let imu_ang_vel = [0.0; 3]; // TOOD: IMU
-        let imu_euler_xyz = [0.0; 3];
-
-        combined_robot_state[35..38].copy_from_slice(&imu_ang_vel);
-        combined_robot_state[38..41].copy_from_slice(&imu_euler_xyz);
-
-        combined_robot_state[41..656].copy_from_slice(&self.prev_buffer);
-
-        Ok(combined_robot_state)
+            .unwrap_or([0.0; 16]);
+        Ok(joint_states)
     }
 
-    async fn model_inference(&mut self, model: &Model, model_input: &[f32; 656]) -> Result<[f32; 16]> {
-
+    async fn model_inference(&self, model: &Model, joint_states: &[f32; 16]) -> Result<[f32; 16]> {
+        //  
         // x_vel: Array1<f32>,
         // y_vel: Array1<f32>,
         // rot: Array1<f32>,
-        // t_sin: Array1<f32>,
-        // t_cos: Array1<f32>, 
+        // t: Array1<f32>,
         // dof_pos: Array1<f32>,
         // dof_vel: Array1<f32>,
         // prev_actions: Array1<f32>,
         // imu_ang_vel: Array1<f32>,
         // imu_euler_xyz: Array1<f32>,
-        // hist_obs: Array1<f32>,
+        // buffer: Array1<f32>,
 
-        let model_output = model.infer(model_input)?;
-        // model output is {"actions": actions_scaled, "actions_raw": actions, "new_x": x}
-        // 10 dim each for actions, 615 dim for new_x
 
-        self.prev_actions.copy_from_slice(&model_output[..10]);  // Store actions
-        self.prev_buffer.copy_from_slice(&model_output[20..635]);
+        let model_output = model.infer(joint_states)?;
 
-        let mut desired_joint_positions = [0.0; 16];  // Initialize all positions to 0.0
-        desired_joint_positions[..10].copy_from_slice(&model_output[..10]);
+        // TODO: Implement proper conversion from model output to desired joint positions
+        let desired_joint_positions: [f32; 16] = model_output.iter()
+            .take(16)
+            .map(|&x| x)
+            .collect::<Vec<f32>>()
+            .try_into()
+            .unwrap_or([0.0; 16]);
 
         Ok(desired_joint_positions)   
     }
@@ -139,13 +96,13 @@ impl Robot{
 }
 
 #[tokio::main]
-pub async fn run(model: Arc<Model>, robot: Arc<Mutex<Robot>>) -> Result<()> {
-    let mut robot = robot.lock().await;
+pub async fn run(model: Arc<Model>, robot: Arc<Robot>) -> Result<()> {
+
     robot.servo.enable_readout()?;  
+
     robot.run(model).await?;
 
     Ok(())
 }
-
 
 

--- a/runtime/src/main.rs
+++ b/runtime/src/main.rs
@@ -13,7 +13,7 @@ async fn main() -> Result<()> {
     let robot = Robot::new().context("Failed to initialize robot")?;
 
     // load model
-    let model_path = PathBuf::from("/root/models/ppo_standing_sin_cos.cvimodel"); // PATH IN MILK-V
+    let model_path = PathBuf::from("/root/models/ppo_walking.cvimodel"); // PATH IN MILK-V
     let model = Model::new(model_path).context("Failed to load model")?;
     let model_arc = Arc::new(model);
 

--- a/runtime/src/main.rs
+++ b/runtime/src/main.rs
@@ -13,7 +13,7 @@ async fn main() -> Result<()> {
     let robot = Robot::new().context("Failed to initialize robot")?;
 
     // load model
-    let model_path = PathBuf::from("/root/models/ppo_walking.cvimodel"); // PATH IN MILK-V
+    let model_path = PathBuf::from("/root/models/ppo_standing_sin_cos.cvimodel"); // PATH IN MILK-V
     let model = Model::new(model_path).context("Failed to load model")?;
     let model_arc = Arc::new(model);
 


### PR DESCRIPTION
Implements milkv kinfer service on kos for zbot2.

We will need a separate metadata file for `.cvimodel` to define the input/output schemas, the inference service implements ProtoIO pack/unpacking for kinfer & talks to the actuators + sensors on kos.

Diagram
```
[ IMU/Actuator Service ] ---telemetry--> [ ZBotInference ] ---ProtoIO---> [ kinfer MilkVModelRunner ]
---ProtoIO---> [ZBotInference] ---actuator commands--> [Actuator Service]
``` 