### PR TITLE
servo configuration fix - add acceleration config - add speed setpoint in position mode

### DIFF
--- a/kos-zbot/src/actuator.rs
+++ b/kos-zbot/src/actuator.rs
@@ -120,6 +120,11 @@ impl Actuator for ZBotActuator {
                 let _ = servo.set_pid(p, i, d);
             }
 
+            // Set acceleration. if none is provided, default to 2230 deg/sec^2 (max).
+            //let acceleration = config.acceleration.unwrap_or(2230);
+            let default_acceleration = 2230;
+            let _ = servo.set_acceleration(default_acceleration as f32);
+
             if let Some(zero_position) = config.zero_position {
                 if zero_position {
                     let result = servo.set_zero_position();

--- a/kos-zbot/src/actuator.rs
+++ b/kos-zbot/src/actuator.rs
@@ -8,7 +8,7 @@ use kos::kos_proto::{
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
-use tracing::{debug, trace, warn};
+use tracing::{debug};
 
 pub struct ZBotActuator {
     supervisor: Arc<RwLock<FeetechSupervisor>>,
@@ -127,6 +127,7 @@ impl Actuator for ZBotActuator {
                 }
         
                 if let Some(zero_position) = config.zero_position {
+                    debug!("zero position");
                     if zero_position {
                         if let Err(e) = servo.set_zero_position() {
                             errors.push(e.into());

--- a/kos-zbot/src/actuator.rs
+++ b/kos-zbot/src/actuator.rs
@@ -118,14 +118,12 @@ impl Actuator for ZBotActuator {
                     }
                 }
 
-                // default 2230 deg/sec^2 (this should not be hardcoded)
-                // what should default be (max, off, something else?)
-                let acceleration = config.acceleration.unwrap_or(2230.0);
-                debug!("acc: {}", acceleration);
-                if let Err(e) = servo.set_acceleration(acceleration as f32) {
-                    errors.push(e.into());
+                if let Some(acceleration) = config.acceleration {
+                    if let Err(e) = servo.set_acceleration(acceleration as f32) {
+                        errors.push(e.into());
+                    }
                 }
-        
+
                 if let Some(zero_position) = config.zero_position {
                     debug!("zero position");
                     if zero_position {

--- a/kos-zbot/src/actuator.rs
+++ b/kos-zbot/src/actuator.rs
@@ -8,6 +8,7 @@ use kos::kos_proto::{
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
+use tracing::{debug, trace, warn};
 
 pub struct ZBotActuator {
     supervisor: Arc<RwLock<FeetechSupervisor>>,
@@ -100,50 +101,69 @@ impl Actuator for ZBotActuator {
 
     async fn configure_actuator(&self, config: ConfigureActuatorRequest) -> Result<ActionResponse> {
         let mut supervisor = self.supervisor.write().await;
-
         let id = config.actuator_id as u8;
+        let mut errors = Vec::new();
+        debug!("configure_actuator [id]:{}", id);
+        
+        {   // <-- block to limit servo lock life
+            let mut servos = supervisor.servos.write().await;
+            if let Some(servo) = servos.get_mut(&id) {
+                // Set PID values if provided.
+                let p = config.kp.map(|v| v as f32);
+                let i = config.ki.map(|v| v as f32);
+                let d = config.kd.map(|v| v as f32);
+                if p.is_some() || i.is_some() || d.is_some() {
+                    if let Err(e) = servo.set_pid(p, i, d) {
+                        errors.push(e.into());
+                    }
+                }
 
+                // default 2230 deg/sec^2 (this should not be hardcoded)
+                // what should default be (max, off, something else?)
+                let acceleration = config.acceleration.unwrap_or(2230.0);
+                debug!("acc: {}", acceleration);
+                if let Err(e) = servo.set_acceleration(acceleration as f32) {
+                    errors.push(e.into());
+                }
+        
+                if let Some(zero_position) = config.zero_position {
+                    if zero_position {
+                        if let Err(e) = servo.set_zero_position() {
+                            errors.push(e.into());
+                        }
+                    }
+                }
+            } else {
+                return Ok(Self::to_action_response(Err(eyre::eyre!("Servo not found"))));
+            }
+        } // <-- servo lock dropoed>
+    
         if let Some(torque_enabled) = config.torque_enabled {
             let result = if torque_enabled {
                 supervisor.enable_torque(id).await
             } else {
                 supervisor.disable_torque(id).await
             };
-
-            return Ok(Self::to_action_response(result));
+            if let Err(e) = result {
+                errors.push(e);
+            }
         }
-
+        
         if let Some(new_actuator_id) = config.new_actuator_id {
             let result = supervisor.change_id(id, new_actuator_id as u8).await;
-            return Ok(Self::to_action_response(result));
+            if let Err(e) = result {
+                errors.push(e);
+            }
         }
-
-        let mut servos = supervisor.servos.write().await;
-        if let Some(servo) = servos.get_mut(&id) {
-            // Set PID values if provided
-            let p = config.kp.map(|v| v as f32);
-            let i = config.ki.map(|v| v as f32);
-            let d = config.kd.map(|v| v as f32);
-            if p.is_some() || i.is_some() || d.is_some() {
-                let _ = servo.set_pid(p, i, d);
-            }
-
-           // Set acceleration. if none is provided, default to 2230 deg/sec^2 (max).
-            //let acceleration = config.acceleration.unwrap_or(2230);
-            let default_acceleration = 2230;
-            let _ = servo.set_acceleration(default_acceleration as f32);
-
-            if let Some(zero_position) = config.zero_position {
-                if zero_position {
-                    let result = servo.set_zero_position();
-                    return Ok(Self::to_action_response(result));
-                }
-            }
-            return Ok(Self::success_response());
+        
+        // Return an aggregated response.
+        if errors.is_empty() {
+            Ok(Self::success_response())
         } else {
-            return Ok(Self::to_action_response(Err(eyre::eyre!("Servo not found"))));
+            Ok(Self::to_action_response(Err(errors.remove(0))))
         }
     }
+    
 
     async fn get_actuators_state(
         &self,

--- a/kos-zbot/src/bin/feetech_accel.rs
+++ b/kos-zbot/src/bin/feetech_accel.rs
@@ -1,0 +1,24 @@
+use kos_zbot::feetech::{feetech_deinit, feetech_init, FeetechActuator};
+use kos_zbot::feetech_servo::Sts3215;
+use std::env;
+
+fn main() {
+    let args: Vec<String> = env::args().collect();
+    if args.len() != 3 {
+        println!("Usage: {} <id> <deg/s^2>", args[0]);
+        return;
+    }
+    let id: u8 = args[1].parse().expect("ID must be a number between 1-255");
+    let acceleration: f32 = args[2].parse().expect("ID must be a number between 0-2230 deg/sec^2");
+
+    feetech_init().unwrap();
+    let mut servo = Sts3215::new(id);
+    if servo.check_id().is_ok() {
+        println!("found servo at [id]:{}", id);
+        println!("setting acceleration {} deg/s^2", acceleration);
+        servo.set_acceleration(acceleration).unwrap();
+    } else {
+        println!("no servo found at [id]:{}", id);
+    }
+    feetech_deinit().unwrap();
+}

--- a/kos-zbot/src/firmware/feetech.rs
+++ b/kos-zbot/src/firmware/feetech.rs
@@ -129,7 +129,7 @@ pub trait FeetechActuator: Send + Sync + std::fmt::Debug {
     fn info(&self) -> FeetechActuatorInfo;
     fn set_position(&mut self, position_deg: f32) -> Result<()>;
     fn set_speed(&mut self, speed_deg_per_s: f32) -> Result<()>;
-    fn set_acceleration(&mut self, speed_deg_per_s2: f32) -> Result<()>;
+    fn set_acceleration(&mut self, accel_deg_per_s2: f32) -> Result<()>;
     fn enable_torque(&mut self) -> Result<()>;
     fn disable_torque(&mut self) -> Result<()>;
     fn change_id(&mut self, id: u8) -> Result<()>;

--- a/kos-zbot/src/firmware/feetech.rs
+++ b/kos-zbot/src/firmware/feetech.rs
@@ -129,6 +129,7 @@ pub trait FeetechActuator: Send + Sync + std::fmt::Debug {
     fn info(&self) -> FeetechActuatorInfo;
     fn set_position(&mut self, position_deg: f32) -> Result<()>;
     fn set_speed(&mut self, speed_deg_per_s: f32) -> Result<()>;
+    fn set_acceleration(&mut self, speed_deg_per_s2: f32) -> Result<()>;
     fn enable_torque(&mut self) -> Result<()>;
     fn disable_torque(&mut self) -> Result<()>;
     fn change_id(&mut self, id: u8) -> Result<()>;

--- a/kos-zbot/src/firmware/feetech_servo/sts3215.rs
+++ b/kos-zbot/src/firmware/feetech_servo/sts3215.rs
@@ -21,6 +21,7 @@ enum Sts3215Register {
     TargetLocation = 0x2A,
     RunningTime = 0x2C,
     RunningSpeed = 0x2E,
+    Acceleration = 0x29,
     TorqueLimit = 0x30,
     LockMark = 0x37,
     CurrentLocation = 0x38,
@@ -125,7 +126,24 @@ impl FeetechActuator for Sts3215 {
         .map_err(|e| eyre!("Failed to set speed: {}", e))?;
         Ok(())
     }
+    
 
+    fn set_acceleration(&mut self, accel_deg_per_s2: f32) -> Result<()> { 
+        let accel_scaled = self.degrees_to_raw(accel_deg_per_s2, 0.0) as f32 / 100.0;
+        let accel_raw = accel_scaled.clamp(0.0, 254.0) as u8;    
+        debug!("Setting acceleration: {} deg/s² -> {} register units", accel_deg_per_s2, accel_raw);
+        
+        feetech_write(
+            self.id,
+            Sts3215Register::Acceleration as u8,
+            &[accel_raw],
+        )
+        .map_err(|e| eyre!("Failed to set acceleration: {}", e))?;
+        
+        Ok(())
+    }
+    
+    
     fn set_operation_mode(&mut self, mode: FeetechOperationMode) -> Result<()> {
         match mode {
             FeetechOperationMode::PositionControl => {

--- a/kos-zbot/src/firmware/feetech_servo/sts3215.rs
+++ b/kos-zbot/src/firmware/feetech_servo/sts3215.rs
@@ -143,7 +143,7 @@ impl FeetechActuator for Sts3215 {
         Ok(())
     }
     
-    
+  
     fn set_operation_mode(&mut self, mode: FeetechOperationMode) -> Result<()> {
         match mode {
             FeetechOperationMode::PositionControl => {
@@ -165,6 +165,7 @@ impl FeetechActuator for Sts3215 {
         self.info.torque_enabled = true;
         feetech_write(self.id, Sts3215Register::TorqueSwitch as u8, &[0x01])
             .map_err(|e| eyre!("Failed to enable torque: {}", e))?;
+        debug!("Torque Enabled [id]: {}", self.id);
         Ok(())
     }
 
@@ -172,6 +173,7 @@ impl FeetechActuator for Sts3215 {
         self.info.torque_enabled = false;
         feetech_write(self.id, Sts3215Register::TorqueSwitch as u8, &[0x00])
             .map_err(|e| eyre!("Failed to disable torque: {}", e))?;
+        debug!("Torque Disabled [id]: {}", self.id);
         Ok(())
     }
 


### PR DESCRIPTION
servo configuration fix - add acceleration config - add target speed for position mode

kos.actuator.configure_actuator(
        actuator_id=16,
        kp=1.0,
        kd=1.0,
        ki=0.01,
        max_torque=100,
        acceleration=500,
        torque_enabled=True
    )
Units deg/sec^2. If no acceleration is passed, default to max acceleration, if zero is passed, disable acceleration

added velocity(deg/sec) target in position mode. move to target at some velocity
```
command_actuators([
    {'actuator_id':11, 'position':100,'velocity':125.0  },
    {'actuator_id':12, 'position':100,'velocity':250.0 } ])
```

The velocities are sent within the sync write packet to allow for instantaneous position command with accompanied velocity.  If velocity is not set, it defaults to max velocity (original behavior)

I've left the time parameter commented out for the time being. Some further testing needs to be done. I was not able to get it function, but will revisit.  